### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/docker/docker-compose-kafka.yml
+++ b/docker/docker-compose-kafka.yml
@@ -8,7 +8,7 @@ services:
       - ./envoy.yaml:/etc/envoy/envoy.yaml
 
   kafka-server:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092:9092"
     environment:


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kafka:4.0` → [`soldevelo/kafka:4.0`](https://hub.docker.com/r/soldevelo/kafka)